### PR TITLE
performance improvement

### DIFF
--- a/TeleportEverything/HarmonyPatches.cs
+++ b/TeleportEverything/HarmonyPatches.cs
@@ -228,9 +228,7 @@ namespace TeleportEverything
             {
                 if (!IsModEnabled()) return;
 
-                if (!ZNetScene.instance.IsAreaReady(__instance.m_teleportTargetPos)) return;
-
-                if (!___m_teleporting && TeleportTriggered)
+                if (!___m_teleporting && TeleportTriggered && ZNetScene.instance.IsAreaReady(__instance.m_teleportTargetPos))
                 {
                     TeleportTriggered = false;
                     //TeleportEverythingLogger.LogInfo("Teleport ended");


### PR DESCRIPTION
Moved heavy operation `IsAreaReady` to only be called once teleporting.

Seems fine in a simple test. Check FPS or use dotTrace before and after change.

#31