### PR TITLE
Fix NullReferenceException on load when PlatformPrefs isn't ready

### DIFF
--- a/TeleportEverything/Declarations.cs
+++ b/TeleportEverything/Declarations.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using BepInEx;
@@ -102,7 +103,8 @@ namespace TeleportEverything
 
         private void Awake()
         {
-            Localizer.Load();
+            // Defer localization until Valheim's PlatformPrefs are initialized (avoids NullReferenceException in PlatformPrefs.TryGetPreferencesProvider during chainload).
+            StartCoroutine(LoadLocalizationWhenReady());
 
             CreateConfigValues();
 
@@ -116,6 +118,28 @@ namespace TeleportEverything
 
             ClearIncludeVars();
             Debug.Log($"{ModName} Loaded...");
+        }
+
+        private static IEnumerator LoadLocalizationWhenReady()
+        {
+            const int maxAttempts = 50;
+            const float delaySeconds = 0.2f;
+            for (int i = 0; i < maxAttempts; ++i)
+            {
+                if (i > 0)
+                    yield return new WaitForSeconds(delaySeconds);
+                try
+                {
+                    Localizer.Load();
+                    TeleportEverythingLogger.LogDebug("Localization loaded.");
+                    yield break;
+                }
+                catch (System.Exception ex)
+                {
+                    if (i == maxAttempts - 1)
+                        TeleportEverythingLogger.LogError($"Failed to load localization after {maxAttempts} attempts: {ex.Message}");
+                }
+            }
         }
 
         private void OnDestroy()


### PR DESCRIPTION
TeleportEverything crashes during BepInEx chainload because it calls `Localizer.Load()` in `Awake()`. That touches Valheim's `Localization.get_instance()`, which initializes and calls `SetStartupLanguage()` → `PlatformPrefs.GetString()` → `PlatformPrefs.TryGetPreferencesProvider()`. At that point the preferences provider isn't set yet, so the game throws a NullReferenceException and the plugin never loads.

Fix: run localization loading from a coroutine that retries every 0.2s until the game has initialized (or after 50 attempts), instead of calling `Localizer.Load()` directly in `Awake()`.

Fixes #41 